### PR TITLE
feat(wizard): Add general purpose event handlers

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -8,6 +8,7 @@ import { Component } from 'react'
 import PropTypes from 'prop-types'
 
 type Props = {
+  onComplete: Function,
   steps: Array<mixed>,
   render: Function,
   children: Function,
@@ -39,7 +40,15 @@ export default class Wizard extends Component<Props, State> {
 
   next = () => {
     const index = this.state.index === this.props.steps.length - 1 ? this.props.steps.length - 1 : this.state.index + 1
+ 
     this.setState({ index })
+
+    if (
+      index === this.props.steps.length - 1 &&
+      typeof this.props.onComplete === 'function'
+    ) {
+      this.props.onComplete()
+    }
   }
 
   prev = () => {

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types'
 
 type Props = {
   onComplete: Function,
+  onUpdate: Function,
   steps: Array<mixed>,
   render: Function,
   children: Function,
@@ -49,11 +50,20 @@ export default class Wizard extends Component<Props, State> {
     ) {
       this.props.onComplete()
     }
+
+    if (typeof this.props.onUpdate === 'function') {
+      this.props.onUpdate({ index })
+    }
   }
 
   prev = () => {
     const index = this.state.index === 0 ? this.state.index : this.state.index - 1
+
     this.setState({ index })
+
+    if (typeof this.props.onUpdate === 'function') {
+      this.props.onUpdate({ index })
+    }
   }
 
   getChildContext() {

--- a/src/__tests__/Wizard.test.js
+++ b/src/__tests__/Wizard.test.js
@@ -165,4 +165,38 @@ describe('<Wizard/>', () => {
     rendered.find('button#next').simulate('click')
     expect(fn.mock.calls.length).toBe(1)
   })
+
+  it('should fire onUpdate on state change', () => {
+    const onUpdate = jest.fn()
+    const onComplete = jest.fn()
+    const rendered = mount(
+      <Wizard
+        steps={[
+          { component: () => <h2>Step One</h2> },
+          { component: () => <h2>Step Two</h2> },
+        ]}
+        onUpdate={onUpdate}
+        onComplete={onComplete}
+      >
+        {() =>
+          <div>
+            <WizardContent/>
+            <Navigation>
+              {({ next, prev }) => (
+                <div>
+                  <button id="next" onClick={next}>Next</button>
+                  <button id="prev" onClick={prev}>Prev</button>
+                </div>
+              )}
+            </Navigation>
+          </div>
+        }
+      </Wizard>
+    )
+
+    rendered.find('button#next').simulate('click')
+    rendered.find('button#prev').simulate('click')
+    expect(onUpdate.mock.calls.length).toBe(2)
+    expect(onComplete.mock.calls.length).toBe(1)
+  })
 })

--- a/src/__tests__/Wizard.test.js
+++ b/src/__tests__/Wizard.test.js
@@ -135,4 +135,34 @@ describe('<Wizard/>', () => {
     expect(rendered.contains(<h2>Step One</h2>)).toBe(false)
     expect(rendered.contains(<h2>Step Three</h2>)).toBe(true)
   })
+
+  it('should fire onComplete when complete', () => {
+    const fn = jest.fn()
+    const rendered = mount(
+      <Wizard
+        steps={[
+          { component: () => <h2>Step One</h2> },
+          { component: () => <h2>Step Two</h2> },
+        ]}
+        onComplete={fn}
+      >
+        {() =>
+          <div>
+            <WizardContent/>
+            <Navigation>
+              {({ next, prev }) => (
+                <div>
+                  <button id="next" onClick={next}>Next</button>
+                  <button id="prev" onClick={prev}>Prev</button>
+                </div>
+              )}
+            </Navigation>
+          </div>
+        }
+      </Wizard>
+    )
+
+    rendered.find('button#next').simulate('click')
+    expect(fn.mock.calls.length).toBe(1)
+  })
 })


### PR DESCRIPTION
Closes #7, which specified both `onUpdate` and `onComplete` as optional handlers. This PR adds both.