### PR TITLE
Refactor to use HOC. Close #33.

### DIFF
--- a/src/Content.js
+++ b/src/Content.js
@@ -5,7 +5,8 @@
 // that can be found in LICENSE.md, at the root of this repository.
 
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
+
+import WizardContext, { type API } from './WizardContext'
 
 const createElementFromStep = s => {
   if (typeof s === 'function') {
@@ -17,23 +18,23 @@ const createElementFromStep = s => {
   }
 }
 
-export default class Content extends Component<void, void> {
-  static contextTypes = {
-    wizard: PropTypes.object,
-  }
+export type Props = {
+  render?: Function,
+  children?: Function,
+  api: API,
+}
 
-  // $FlowIgnore
-  get currentStep() {
-    const { steps, index } = this.context.wizard
-    if (typeof steps[index] !== 'undefined') {
-      return createElementFromStep(steps[index])
+class Content extends Component<Props, void> {
+  render() {
+    const { api: { steps, index } } = this.props
+    const Step = createElementFromStep(steps[index])
+
+    if (Step) {
+      return <Step/>
     }
+
     return null
   }
-
-  render() {
-    // $FlowIgnore
-    const Component = this.currentStep
-    return <Component/>
-  }
 }
+
+export default WizardContext(Content)

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -5,30 +5,29 @@
 // that can be found in LICENSE.md, at the root of this repository.
 
 import { Component } from 'react'
-import PropTypes from 'prop-types'
+
+import WizardContext, { type API } from './WizardContext'
 
 type Props = {
   render?: Function,
   children?: Function,
+  api: API,
 }
 
-export default class Nav extends Component<Props, void> {
-  static contextTypes = {
-    wizard: PropTypes.object,
-  }
-
+class Nav extends Component<Props, void> {
   render() {
-    const { render, children } = this.props
-    const props = this.context.wizard
+    const { api, render, children } = this.props
 
     if (render) {
-      return render(props)
+      return render(api)
     }
 
     if (children) {
-      return children(props)
+      return children(api)
     }
 
     return null
   }
 }
+
+export default WizardContext(Nav)

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -8,9 +8,9 @@ import { Component } from 'react'
 import PropTypes from 'prop-types'
 
 export type Step = {
-  name: string,
-  component?: string,
-  render?: string,
+  name: Function,
+  component?: Function,
+  render?: Function,
 }
 
 export type Props = {

--- a/src/WizardContext.js
+++ b/src/WizardContext.js
@@ -1,0 +1,46 @@
+// @flow
+
+// Copyright 2017 Uptime Ventures, Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in LICENSE.md, at the root of this repository.
+
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+export type Props = {
+  render?: Function,
+  children?: Function,
+}
+
+type Step = {
+  name: string,
+  component?: Function,
+  render?: Function,
+}
+
+export type API = {
+  steps: Array<Function | Step>,
+  index: number,
+  next: Function,
+  prev: Function,
+  jump: Function,
+}
+
+function WizardContext(WrappedComponent: Function) {
+  class WizardComponent extends Component<Props, null> {
+    static contextTypes = {
+      wizard: PropTypes.object,
+    }
+
+    render() {
+      const api = this.context.wizard
+      return (
+        <WrappedComponent api={api} {...this.props}/>
+      )
+    }
+  }
+
+  return WizardComponent
+}
+
+export default WizardContext


### PR DESCRIPTION
 The changes below migrate overall component structure to rely on the HOC `<WizardContext/>`. I've also included a few housekeeping items.